### PR TITLE
Add grouped flat task list with collapsible functionality

### DIFF
--- a/app.js
+++ b/app.js
@@ -837,6 +837,8 @@ function switchPreviewTab(targetTab) {
     // 特定タブの初期化処理
     if (targetTab === 'all-tasks') {
         renderAllNodesTasks();
+    } else if (targetTab === 'task-list') {
+        renderFlatTaskList();
     } else if (targetTab === 'tasks') {
         updateTaskNodeSelect();
     }

--- a/dataManager.js
+++ b/dataManager.js
@@ -28,6 +28,13 @@ const STORAGE_KEYS = {
 // データバージョン
 const CURRENT_DATA_VERSION = '1.0.0';
 
+// デフォルトのフラットタスクグループ折りたたみ状態
+const DEFAULT_FLAT_TASK_GROUP_COLLAPSED = {
+    'incomplete': false,        // 未完了タスク：デフォルト展開
+    'blocked_incomplete': false, // ブロック中の未完了タスク：デフォルト展開
+    'completed': true           // 完了タスク：デフォルト折りたたみ
+};
+
 // LocalStorageが利用可能かチェック
 function isLocalStorageAvailable() {
     try {
@@ -156,11 +163,7 @@ function loadProjectData(project) {
     nodeCardCollapsed = {...project.data.nodeCardCollapsed};
     nodeChatHistory = {...(project.data.nodeChatHistory || {})};
     flatTaskGroupCollapsed = {
-        ...{
-            'incomplete': false,
-            'blocked_incomplete': false,
-            'completed': true
-        },
+        ...DEFAULT_FLAT_TASK_GROUP_COLLAPSED,
         ...(project.data.flatTaskGroupCollapsed || {})
     };
 }
@@ -413,11 +416,7 @@ function loadFromLocalStorage() {
             flatTaskGroupCollapsed = JSON.parse(savedFlatTaskGroupCollapsed);
         } else {
             // デフォルト値を設定
-            flatTaskGroupCollapsed = {
-                'incomplete': false,        // 未完了タスク：デフォルト展開
-                'blocked_incomplete': false, // ブロック中の未完了タスク：デフォルト展開
-                'completed': true           // 完了タスク：デフォルト折りたたみ
-            };
+            flatTaskGroupCollapsed = {...DEFAULT_FLAT_TASK_GROUP_COLLAPSED};
         }
         
         console.log('Data loaded from localStorage successfully');
@@ -440,11 +439,7 @@ function initializeWithDefaultData() {
     nodeStatuses = {};
     nodeCardCollapsed = {};
     nodeChatHistory = {};
-    flatTaskGroupCollapsed = {
-        'incomplete': false,        // 未完了タスク：デフォルト展開
-        'blocked_incomplete': false, // ブロック中の未完了タスク：デフォルト展開
-        'completed': true           // 完了タスク：デフォルト折りたたみ
-    };
+    flatTaskGroupCollapsed = {...DEFAULT_FLAT_TASK_GROUP_COLLAPSED};
     console.log('Initialized with default data');
 }
 

--- a/dataManager.js
+++ b/dataManager.js
@@ -16,6 +16,7 @@ const STORAGE_KEYS = {
     NODE_STATUSES: 'graphEditor_nodeStatuses',
     NODE_CARD_COLLAPSED: 'graphEditor_nodeCardCollapsed',
     NODE_CHAT_HISTORY: 'graphEditor_nodeChatHistory',
+    FLAT_TASK_GROUP_COLLAPSED: 'graphEditor_flatTaskGroupCollapsed',
     DATA_VERSION: 'graphEditor_dataVersion',
     // プロジェクト管理
     PROJECTS: 'graphEditor_projects',
@@ -134,7 +135,8 @@ function saveCurrentProjectData() {
             nodeTasks: {...nodeTasks},
             nodeStatuses: {...nodeStatuses},
             nodeCardCollapsed: {...nodeCardCollapsed},
-            nodeChatHistory: {...nodeChatHistory}
+            nodeChatHistory: {...nodeChatHistory},
+            flatTaskGroupCollapsed: {...flatTaskGroupCollapsed}
         };
         project.updatedAt = new Date().toISOString();
         return true;
@@ -153,6 +155,14 @@ function loadProjectData(project) {
     nodeStatuses = {...project.data.nodeStatuses};
     nodeCardCollapsed = {...project.data.nodeCardCollapsed};
     nodeChatHistory = {...(project.data.nodeChatHistory || {})};
+    flatTaskGroupCollapsed = {
+        ...{
+            'incomplete': false,
+            'blocked_incomplete': false,
+            'completed': true
+        },
+        ...(project.data.flatTaskGroupCollapsed || {})
+    };
 }
 
 /**
@@ -303,6 +313,7 @@ function saveToLocalStorageImmediate() {
             localStorage.setItem(STORAGE_KEYS.NODE_STATUSES, JSON.stringify(nodeStatuses));
             localStorage.setItem(STORAGE_KEYS.NODE_CARD_COLLAPSED, JSON.stringify(nodeCardCollapsed));
             localStorage.setItem(STORAGE_KEYS.NODE_CHAT_HISTORY, JSON.stringify(nodeChatHistory));
+            localStorage.setItem(STORAGE_KEYS.FLAT_TASK_GROUP_COLLAPSED, JSON.stringify(flatTaskGroupCollapsed));
         }
         
         console.log('Data saved to localStorage successfully');
@@ -353,6 +364,7 @@ function loadFromLocalStorage() {
         const savedNodeStatuses = localStorage.getItem(STORAGE_KEYS.NODE_STATUSES);
         const savedNodeCardCollapsed = localStorage.getItem(STORAGE_KEYS.NODE_CARD_COLLAPSED);
         const savedNodeChatHistory = localStorage.getItem(STORAGE_KEYS.NODE_CHAT_HISTORY);
+        const savedFlatTaskGroupCollapsed = localStorage.getItem(STORAGE_KEYS.FLAT_TASK_GROUP_COLLAPSED);
         
         // データがある場合のみ復元
         if (savedNodes) {
@@ -397,6 +409,17 @@ function loadFromLocalStorage() {
             nodeChatHistory = {};
         }
         
+        if (savedFlatTaskGroupCollapsed) {
+            flatTaskGroupCollapsed = JSON.parse(savedFlatTaskGroupCollapsed);
+        } else {
+            // デフォルト値を設定
+            flatTaskGroupCollapsed = {
+                'incomplete': false,        // 未完了タスク：デフォルト展開
+                'blocked_incomplete': false, // ブロック中の未完了タスク：デフォルト展開
+                'completed': true           // 完了タスク：デフォルト折りたたみ
+            };
+        }
+        
         console.log('Data loaded from localStorage successfully');
         return true;
     } catch (e) {
@@ -417,6 +440,11 @@ function initializeWithDefaultData() {
     nodeStatuses = {};
     nodeCardCollapsed = {};
     nodeChatHistory = {};
+    flatTaskGroupCollapsed = {
+        'incomplete': false,        // 未完了タスク：デフォルト展開
+        'blocked_incomplete': false, // ブロック中の未完了タスク：デフォルト展開
+        'completed': true           // 完了タスク：デフォルト折りたたみ
+    };
     console.log('Initialized with default data');
 }
 

--- a/index.html
+++ b/index.html
@@ -1325,6 +1325,9 @@
                     <button class="preview-tab-button active" data-preview-tab="all-tasks">
                         📋 全ノード表示
                     </button>
+                    <button class="preview-tab-button" data-preview-tab="task-list">
+                        📝 タスクリスト
+                    </button>
                     <button class="preview-tab-button" data-preview-tab="tasks">
                         📋 ノードタスク管理
                     </button>
@@ -1363,6 +1366,14 @@
                                 placeholder="新しいノードを入力... (Enterで追加)">
                             <button class="add-task-button" onclick="addGlobalNewNode()">追加</button>
                         </div>
+                    </div>
+                </div>
+                
+                <!-- タスクフラットリスト表示セクション -->
+                <div class="section task-list-section" data-preview-section="task-list" style="display: none;">
+                    <h3>📝 タスクフラットリスト</h3>
+                    <div id="flat-task-container" style="max-height: 600px; overflow-y: auto;">
+                        <!-- フラットなタスクリストがここに表示される -->
                     </div>
                 </div>
                 

--- a/index.html
+++ b/index.html
@@ -1188,6 +1188,119 @@
         .memo-edit-cancel:hover {
             background: #4b5563;
         }
+        
+        /* フラットタスクリスト関連のスタイル */
+        .flat-task-container {
+            max-height: 600px;
+            overflow-y: auto;
+        }
+        
+        .flat-task-group {
+            margin-bottom: 20px;
+            border: 1px solid #e5e7eb;
+            border-radius: 8px;
+            background: white;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+            overflow: hidden;
+        }
+        
+        .flat-group-header {
+            border-bottom: 1px solid #e5e7eb;
+            padding: 12px 16px;
+            cursor: pointer;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            user-select: none;
+            transition: background-color 0.2s ease;
+        }
+        
+        .flat-group-header-content {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        
+        .expand-icon {
+            font-size: 14px;
+            transition: transform 0.2s ease;
+        }
+        
+        .group-title {
+            font-weight: 600;
+            font-size: 14px;
+        }
+        
+        .group-count {
+            color: white;
+            padding: 2px 8px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+        }
+        
+        .flat-task-list {
+            padding: 8px;
+        }
+        
+        .flat-task-item {
+            background: #fafafa;
+            border: 1px solid #e5e7eb;
+            border-radius: 6px;
+            padding: 12px;
+            margin-bottom: 8px;
+            transition: all 0.2s ease;
+        }
+        
+        .flat-task-item:hover {
+            background: white;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+        
+        .flat-task-content {
+            display: flex;
+            align-items: flex-start;
+            gap: 12px;
+        }
+        
+        .flat-task-checkbox {
+            margin-top: 4px;
+            flex-shrink: 0;
+        }
+        
+        .flat-task-text-container {
+            flex: 1;
+            min-width: 0;
+        }
+        
+        .flat-task-text {
+            font-size: 16px;
+            font-weight: 600;
+            line-height: 1.4;
+            margin-bottom: 4px;
+        }
+        
+        .flat-task-text.completed {
+            color: #6b7280;
+            text-decoration: line-through;
+        }
+        
+        .flat-task-text.incomplete {
+            color: #1f2937;
+        }
+        
+        .flat-task-node {
+            font-size: 12px;
+            color: #9ca3af;
+            font-weight: 500;
+        }
+        
+        .no-tasks-message {
+            color: #9ca3af;
+            text-align: center;
+            padding: 40px;
+            font-style: italic;
+        }
     </style>
 </head>
 <body>
@@ -1372,7 +1485,7 @@
                 <!-- タスクフラットリスト表示セクション -->
                 <div class="section task-list-section" data-preview-section="task-list" style="display: none;">
                     <h3>📝 タスクフラットリスト</h3>
-                    <div id="flat-task-container" style="max-height: 600px; overflow-y: auto;">
+                    <div id="flat-task-container" class="flat-task-container">
                         <!-- フラットなタスクリストがここに表示される -->
                     </div>
                 </div>

--- a/taskManager.js
+++ b/taskManager.js
@@ -1021,10 +1021,25 @@ document.addEventListener('click', function(e) {
 }, true); // キャプチャフェーズで実行
 
 // グループの折りたたみ状態を管理
-let flatTaskGroupCollapsed = {
-    'incomplete': false,        // 未完了タスク：デフォルト展開
-    'blocked_incomplete': false, // ブロック中の未完了タスク：デフォルト展開
-    'completed': true           // 完了タスク：デフォルト折りたたみ
+let flatTaskGroupCollapsed = {...DEFAULT_FLAT_TASK_GROUP_COLLAPSED};
+
+// タスクグループ設定
+const TASK_GROUP_CONFIG = {
+    incomplete: {
+        id: 'incomplete',
+        title: '📝 未完了タスク',
+        color: '#3b82f6'
+    },
+    blocked_incomplete: {
+        id: 'blocked_incomplete',
+        title: '⚠️ ブロック中タスク',
+        color: '#f59e0b'
+    },
+    completed: {
+        id: 'completed',
+        title: '✅ 完了タスク',
+        color: '#059669'
+    }
 };
 
 /**
@@ -1071,14 +1086,14 @@ function renderFlatTaskList() {
     // 全てのグループが空の場合
     const totalTasks = taskGroups.incomplete.length + taskGroups.blocked_incomplete.length + taskGroups.completed.length;
     if (totalTasks === 0) {
-        container.innerHTML = '<div style="color: #9ca3af; text-align: center; padding: 40px; font-style: italic;">タスクがありません</div>';
+        container.innerHTML = '<div class="no-tasks-message">タスクがありません</div>';
         return;
     }
     
     // グループを描画
-    renderTaskGroup(container, 'incomplete', '📝 未完了タスク', taskGroups.incomplete, '#3b82f6');
-    renderTaskGroup(container, 'blocked_incomplete', '⚠️ ブロック中タスク', taskGroups.blocked_incomplete, '#f59e0b');
-    renderTaskGroup(container, 'completed', '✅ 完了タスク', taskGroups.completed, '#059669');
+    Object.values(TASK_GROUP_CONFIG).forEach(groupConfig => {
+        renderTaskGroup(container, groupConfig.id, groupConfig.title, taskGroups[groupConfig.id], groupConfig.color);
+    });
 }
 
 /**
@@ -1095,54 +1110,39 @@ function renderTaskGroup(container, groupId, groupTitle, tasks, color) {
     const groupContainer = document.createElement('div');
     groupContainer.className = 'flat-task-group';
     groupContainer.setAttribute('data-group-id', groupId);
-    groupContainer.style.cssText = `
-        margin-bottom: 20px;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
-        background: white;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-        overflow: hidden;
-    `;
     
     // グループヘッダー
     const groupHeader = document.createElement('div');
     groupHeader.className = 'flat-group-header';
-    groupHeader.style.cssText = `
-        background: ${color}08;
-        border-bottom: 1px solid #e5e7eb;
-        padding: 12px 16px;
-        cursor: pointer;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        user-select: none;
-        transition: background-color 0.2s ease;
-    `;
+    groupHeader.style.backgroundColor = `${color}08`;
     
     const isCollapsed = flatTaskGroupCollapsed[groupId];
-    groupHeader.innerHTML = `
-        <div style="display: flex; align-items: center; gap: 8px;">
-            <span class="expand-icon" style="
-                font-size: 14px;
-                color: ${color};
-                transition: transform 0.2s ease;
-                transform: ${isCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)'};
-            ">▼</span>
-            <span style="font-weight: 600; color: ${color}; font-size: 14px;">
-                ${groupTitle}
-            </span>
-        </div>
-        <span style="
-            background: ${color};
-            color: white;
-            padding: 2px 8px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-        ">
-            ${tasks.length}
-        </span>
-    `;
+    
+    // ヘッダーコンテンツ
+    const headerContent = document.createElement('div');
+    headerContent.className = 'flat-group-header-content';
+    
+    const expandIcon = document.createElement('span');
+    expandIcon.className = 'expand-icon';
+    expandIcon.style.color = color;
+    expandIcon.style.transform = isCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)';
+    expandIcon.textContent = '▼';
+    
+    const groupTitleSpan = document.createElement('span');
+    groupTitleSpan.className = 'group-title';
+    groupTitleSpan.style.color = color;
+    groupTitleSpan.textContent = groupTitle;
+    
+    headerContent.appendChild(expandIcon);
+    headerContent.appendChild(groupTitleSpan);
+    
+    const groupCount = document.createElement('span');
+    groupCount.className = 'group-count';
+    groupCount.style.backgroundColor = color;
+    groupCount.textContent = tasks.length;
+    
+    groupHeader.appendChild(headerContent);
+    groupHeader.appendChild(groupCount);
     
     // ホバーエフェクト
     groupHeader.addEventListener('mouseenter', function() {
@@ -1163,63 +1163,48 @@ function renderTaskGroup(container, groupId, groupTitle, tasks, color) {
     // タスクリストコンテナ
     const taskListContainer = document.createElement('div');
     taskListContainer.className = 'flat-task-list';
-    taskListContainer.style.cssText = `
-        display: ${isCollapsed ? 'none' : 'block'};
-        padding: 8px;
-    `;
+    taskListContainer.style.display = isCollapsed ? 'none' : 'block';
     
     // タスクを描画
     tasks.forEach(task => {
         const taskItem = document.createElement('div');
         taskItem.className = 'flat-task-item';
-        taskItem.style.cssText = `
-            background: #fafafa;
-            border: 1px solid #e5e7eb;
-            border-radius: 6px;
-            padding: 12px;
-            margin-bottom: 8px;
-            transition: all 0.2s ease;
-        `;
         
-        taskItem.innerHTML = `
-            <div style="display: flex; align-items: flex-start; gap: 12px;">
-                <input type="checkbox" 
-                       ${task.completed ? 'checked' : ''} 
-                       onchange="toggleFlatTaskCompletion(${task.nodeIndex}, '${task.id}')"
-                       style="margin-top: 4px; flex-shrink: 0;">
-                <div style="flex: 1; min-width: 0;">
-                    <div class="flat-task-text" style="
-                        font-size: 16px;
-                        font-weight: 600;
-                        color: ${task.completed ? '#6b7280' : '#1f2937'};
-                        line-height: 1.4;
-                        margin-bottom: 4px;
-                        ${task.completed ? 'text-decoration: line-through;' : ''}
-                    ">
-                        ${escapeHtml(task.text)}
-                    </div>
-                    <div class="flat-task-node" style="
-                        font-size: 12px;
-                        color: #9ca3af;
-                        font-weight: 500;
-                    ">
-                        📍 ${escapeHtml(task.nodeName)}${task.isNodeBlocked ? ' (保留中)' : ''}
-                    </div>
-                </div>
-            </div>
-        `;
+        const taskContent = document.createElement('div');
+        taskContent.className = 'flat-task-content';
+        
+        const taskCheckbox = document.createElement('input');
+        taskCheckbox.type = 'checkbox';
+        taskCheckbox.className = 'flat-task-checkbox';
+        taskCheckbox.checked = task.completed;
+        taskCheckbox.addEventListener('change', () => toggleFlatTaskCompletion(task.nodeIndex, task.id));
+        
+        const taskTextContainer = document.createElement('div');
+        taskTextContainer.className = 'flat-task-text-container';
+        
+        const taskText = document.createElement('div');
+        taskText.className = `flat-task-text ${task.completed ? 'completed' : 'incomplete'}`;
+        taskText.textContent = task.text;
+        
+        const taskNode = document.createElement('div');
+        taskNode.className = 'flat-task-node';
+        taskNode.textContent = `📍 ${task.nodeName}${task.isNodeBlocked ? ' (保留中)' : ''}`;
+        
+        taskTextContainer.appendChild(taskText);
+        taskTextContainer.appendChild(taskNode);
+        
+        taskContent.appendChild(taskCheckbox);
+        taskContent.appendChild(taskTextContainer);
+        
+        taskItem.appendChild(taskContent);
         
         // ホバーエフェクト
         taskItem.addEventListener('mouseenter', function() {
-            this.style.backgroundColor = 'white';
             this.style.borderColor = color;
-            this.style.boxShadow = '0 2px 8px rgba(0, 0, 0, 0.1)';
         });
         
         taskItem.addEventListener('mouseleave', function() {
-            this.style.backgroundColor = '#fafafa';
             this.style.borderColor = '#e5e7eb';
-            this.style.boxShadow = 'none';
         });
         
         taskListContainer.appendChild(taskItem);
@@ -1266,7 +1251,7 @@ function toggleFlatTaskGroup(groupId) {
  */
 function toggleFlatTaskCompletion(nodeIndex, taskId) {
     const result = toggleTaskCompletion(nodeIndex, taskId);
-    if (result) {
+    if (result !== null) {
         // フラットリストを再描画（グループ間移動対応）
         renderFlatTaskList();
         // 全体進捗も更新


### PR DESCRIPTION
## Summary
- Add new "📝 タスクリスト" tab for enhanced task management
- Implement intelligent task grouping by completion status and node block state
- Add collapsible group headers for better organization
- Ensure persistent state management across sessions

## Features Added

### 🎯 Task Grouping
- **📝 未完了タスク** (blue) - Regular incomplete tasks (default expanded)
- **⚠️ ブロック中タスク** (orange) - Tasks from nodes in "on_hold" status (default expanded)  
- **✅ 完了タスク** (green) - Completed tasks (default collapsed)

### 🔧 User Interface
- Large task names (16px, bold) for better readability
- Small node names (12px, gray) with location indicator
- Group headers with task counts and expand/collapse icons
- Hover effects for enhanced interaction feedback
- Automatic grouping updates when task status changes

### 💾 Data Management
- Persistent collapse state via localStorage
- Project-aware state management
- Full import/export compatibility
- Backward compatibility maintained

### 🔄 Integration
- Seamless integration with existing task management
- Real-time updates with overall progress tracking
- Synchronized with "全ノード表示" functionality

## Technical Implementation
- Enhanced DOM element selection using data attributes
- Robust group toggle functionality
- Modular code organization following existing patterns
- Performance-optimized rendering

## Test Plan
- [x] Task grouping works correctly based on completion status and node state
- [x] Collapse/expand functionality works for all groups
- [x] State persistence across page reloads
- [x] Task completion triggers correct group reassignment
- [x] Integration with existing task management features
- [x] Project switching maintains independent states

🤖 Generated with [Claude Code](https://claude.ai/code)