### PR TITLE
Add status-grouped node display and mobile UX improvements

### DIFF
--- a/app.js
+++ b/app.js
@@ -63,6 +63,9 @@ let nodeStatuses = {};
 // ノードカード折りたたみ状態管理
 let nodeCardCollapsed = {};
 
+// ノードステータスグループ折りたたみ状態管理
+let nodeStatusGroupCollapsed = {};
+
 // プロジェクト管理データ
 let projects = [];
 let currentProjectId = null;

--- a/dataManager.js
+++ b/dataManager.js
@@ -15,6 +15,7 @@ const STORAGE_KEYS = {
     NODE_TASKS: 'graphEditor_nodeTasks',
     NODE_STATUSES: 'graphEditor_nodeStatuses',
     NODE_CARD_COLLAPSED: 'graphEditor_nodeCardCollapsed',
+    NODE_STATUS_GROUP_COLLAPSED: 'graphEditor_nodeStatusGroupCollapsed',
     FLAT_TASK_GROUP_COLLAPSED: 'graphEditor_flatTaskGroupCollapsed',
     DATA_VERSION: 'graphEditor_dataVersion',
     // プロジェクト管理
@@ -311,6 +312,7 @@ function saveToLocalStorageImmediate() {
             localStorage.setItem(STORAGE_KEYS.NODE_TASKS, JSON.stringify(nodeTasks));
             localStorage.setItem(STORAGE_KEYS.NODE_STATUSES, JSON.stringify(nodeStatuses));
             localStorage.setItem(STORAGE_KEYS.NODE_CARD_COLLAPSED, JSON.stringify(nodeCardCollapsed));
+            localStorage.setItem(STORAGE_KEYS.NODE_STATUS_GROUP_COLLAPSED, JSON.stringify(nodeStatusGroupCollapsed));
             localStorage.setItem(STORAGE_KEYS.PROJECT_CHAT_HISTORY, JSON.stringify(projectChatHistory));
             localStorage.setItem(STORAGE_KEYS.NODE_MEMOS, JSON.stringify(nodeMemos));
             localStorage.setItem(STORAGE_KEYS.FLAT_TASK_GROUP_COLLAPSED, JSON.stringify(flatTaskGroupCollapsed));
@@ -363,6 +365,7 @@ function loadFromLocalStorage() {
         const savedNodeTasks = localStorage.getItem(STORAGE_KEYS.NODE_TASKS);
         const savedNodeStatuses = localStorage.getItem(STORAGE_KEYS.NODE_STATUSES);
         const savedNodeCardCollapsed = localStorage.getItem(STORAGE_KEYS.NODE_CARD_COLLAPSED);
+        const savedNodeStatusGroupCollapsed = localStorage.getItem(STORAGE_KEYS.NODE_STATUS_GROUP_COLLAPSED);
         const savedProjectChatHistory = localStorage.getItem(STORAGE_KEYS.PROJECT_CHAT_HISTORY);
         const savedNodeMemos = localStorage.getItem(STORAGE_KEYS.NODE_MEMOS);
         const savedFlatTaskGroupCollapsed = localStorage.getItem(STORAGE_KEYS.FLAT_TASK_GROUP_COLLAPSED);
@@ -402,6 +405,12 @@ function loadFromLocalStorage() {
             nodeCardCollapsed = JSON.parse(savedNodeCardCollapsed);
         } else {
             nodeCardCollapsed = {};
+        }
+        
+        if (savedNodeStatusGroupCollapsed) {
+            nodeStatusGroupCollapsed = JSON.parse(savedNodeStatusGroupCollapsed);
+        } else {
+            nodeStatusGroupCollapsed = {};
         }
         
         

--- a/index.html
+++ b/index.html
@@ -960,6 +960,72 @@
             overflow: hidden;
         }
         
+        .node-status-group {
+            margin-bottom: 24px;
+            border-radius: 8px;
+            border: 1px solid #e5e7eb;
+            background: white;
+            overflow: hidden;
+        }
+        
+        .node-status-group-header {
+            cursor: pointer;
+            transition: background-color 0.2s ease;
+            user-select: none;
+        }
+        
+        .node-status-group-content {
+            transition: all 0.3s ease;
+        }
+        
+        .node-status-group-content .node-task-group {
+            margin-bottom: 12px;
+            margin-left: 16px;
+            margin-right: 16px;
+            border-left: 3px solid #e5e7eb;
+            border-right: none;
+            border-top: 1px solid #e5e7eb;
+            border-bottom: 1px solid #e5e7eb;
+            border-radius: 0 8px 8px 0;
+            box-shadow: none;
+            background: #fafbfc;
+        }
+        
+        .node-status-group-content .node-task-group:first-child {
+            border-top-left-radius: 0;
+            border-top-right-radius: 8px;
+        }
+        
+        .node-status-group-content .node-task-group:last-child {
+            margin-bottom: 16px;
+            border-bottom-left-radius: 0;
+            border-bottom-right-radius: 8px;
+        }
+        
+        /* 未完了グループのノードは特別なスタイル */
+        .node-status-group[data-status-group="not_started"] .node-status-group-content .node-task-group {
+            border-left: 3px solid #6b7280;
+            background: #f8f9fa;
+        }
+        
+        /* 進行中グループのノードは黄色のアクセント */
+        .node-status-group[data-status-group="in_progress"] .node-status-group-content .node-task-group {
+            border-left: 3px solid #f59e0b;
+            background: #fffbeb;
+        }
+        
+        /* 保留グループのノードは赤のアクセント */
+        .node-status-group[data-status-group="on_hold"] .node-status-group-content .node-task-group {
+            border-left: 3px solid #ef4444;
+            background: #fef2f2;
+        }
+        
+        /* 完了グループのノードは緑のアクセント */
+        .node-status-group[data-status-group="completed"] .node-status-group-content .node-task-group {
+            border-left: 3px solid #10b981;
+            background: #f0fdf4;
+        }
+        
         .node-header {
             border-bottom: 1px solid #e5e7eb;
             padding: 12px 16px;
@@ -1000,6 +1066,11 @@
         
         .tasks-list {
             padding: 16px;
+        }
+        
+        /* ステータスグループ内のタスクリストはより控えめなパディング */
+        .node-status-group-content .tasks-list {
+            padding: 12px 16px;
         }
         
         .add-task-form {

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>グラフエディタ</title>
     <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
     <style>


### PR DESCRIPTION
## Summary
- ステータス別ノード表示機能の実装（未開始・進行中・保留・完了でグループ化）
- モバイルでのテキスト入力時の自動ズーム問題を修正
- ノードステータスグループの折りたたみ機能追加

## Features
- **Status-grouped node display**: ノードを進捗ステータスごとにグループ化して表示
- **Collapsible groups**: 各ステータスグループは折りたたみ可能
- **Mobile zoom fix**: テキストエリア入力時の自動ズームを防止

## Test plan
- [ ] ノードステータスが正しくグループ化されることを確認
- [ ] グループの折りたたみ機能が動作することを確認  
- [ ] モバイル端末でテキスト入力時にズームしないことを確認
- [ ] 既存のタスク管理機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)